### PR TITLE
Add trading environment

### DIFF
--- a/TradingEnv.py
+++ b/TradingEnv.py
@@ -1,0 +1,59 @@
+import gymnasium as gym
+from gymnasium import spaces
+import numpy as np
+import pandas as pd
+
+class TradingEnv(gym.Env):
+    def __init__(self, DataFrame: pd.DataFrame, WindowSize: int = 10, InitialBalance: float = 1000.0):
+        super().__init__()
+        self.DataFrame = DataFrame.reset_index(drop=True)
+        self.WindowSize = WindowSize
+        self.InitialBalance = InitialBalance
+        self.CurrentBalance = self.InitialBalance
+        self.SharesHeld = 0
+        self.CurrentStep = self.WindowSize
+        self.ActionSpace = spaces.Discrete(3)
+        self.ObservationSpace = spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(self.WindowSize, self.DataFrame.shape[1]),
+            dtype=np.float32
+        )
+        self.action_space = self.ActionSpace
+        self.observation_space = self.ObservationSpace
+
+    def _GetObservation(self):
+        Frame = self.DataFrame.iloc[self.CurrentStep - self.WindowSize:self.CurrentStep]
+        return Frame.values.astype(np.float32)
+
+    def Reset(self, seed=None, options=None):
+        super().reset(seed=seed)
+        self.CurrentBalance = self.InitialBalance
+        self.SharesHeld = 0
+        self.CurrentStep = self.WindowSize
+        Observation = self._GetObservation()
+        Info = {"balance": self.CurrentBalance, "shares_held": self.SharesHeld}
+        return Observation, Info
+
+    def Step(self, Action: int):
+        Price = float(self.DataFrame.loc[self.CurrentStep, "Close"])
+        PortfolioValue = self.CurrentBalance + self.SharesHeld * Price
+        if Action == 1:
+            SharesToBuy = int(self.CurrentBalance // Price)
+            self.CurrentBalance -= SharesToBuy * Price
+            self.SharesHeld += SharesToBuy
+        elif Action == 2:
+            self.CurrentBalance += self.SharesHeld * Price
+            self.SharesHeld = 0
+        self.CurrentStep += 1
+        if self.CurrentStep >= len(self.DataFrame):
+            self.CurrentStep = len(self.DataFrame) - 1
+            Terminated = True
+        else:
+            Terminated = False
+        NextPrice = float(self.DataFrame.loc[self.CurrentStep, "Close"])
+        NextValue = self.CurrentBalance + self.SharesHeld * NextPrice
+        Reward = NextValue - PortfolioValue
+        Observation = self._GetObservation()
+        Info = {"balance": self.CurrentBalance, "shares_held": self.SharesHeld}
+        return Observation, Reward, Terminated, False, Info

--- a/main.py
+++ b/main.py
@@ -1,0 +1,17 @@
+from DataDownloader import YFinanceDownloader
+from TradingEnv import TradingEnv
+
+
+def Main():
+    Downloader = YFinanceDownloader("AAPL", "2023-01-01", "2023-01-15", "1d")
+    Data = Downloader.DownloadData()
+    Environment = TradingEnv(DataFrame=Data, WindowSize=5, InitialBalance=1000)
+    Observation, Info = Environment.Reset()
+    Done = False
+    while not Done:
+        Action = Environment.action_space.sample()
+        Observation, Reward, Done, _, Info = Environment.Step(Action)
+
+
+if __name__ == "__main__":
+    Main()


### PR DESCRIPTION
## Summary
- implement simple TradingEnv that follows Gymnasium interface
- add a sample main program demonstrating usage

## Testing
- `python -m unittest TestTradingEnv.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ca63be8c832086ff7453e251f014