### PR TITLE
Add DQN trading agent with hold action

### DIFF
--- a/DqnTradingAgent.py
+++ b/DqnTradingAgent.py
@@ -1,0 +1,13 @@
+from stable_baselines3 import DQN
+
+class DqnTradingAgent:
+    def __init__(self, Environment):
+        self.Environment = Environment
+        self.Model = DQN("MlpPolicy", self.Environment, verbose=0)
+
+    def Train(self, Timesteps: int = 1000):
+        self.Model.learn(total_timesteps=Timesteps)
+
+    def Predict(self, Observation):
+        Action, _ = self.Model.predict(Observation)
+        return Action

--- a/TradingEnv.py
+++ b/TradingEnv.py
@@ -35,10 +35,17 @@ class TradingEnv(gym.Env):
         Info = {"balance": self.CurrentBalance, "shares_held": self.SharesHeld}
         return Observation, Info
 
+    # Compatibility methods for libraries expecting lower-case names
+    def reset(self, seed=None, options=None):
+        return self.Reset(seed=seed, options=options)
+
     def Step(self, Action: int):
         Price = float(self.DataFrame.loc[self.CurrentStep, "Close"])
         PortfolioValue = self.CurrentBalance + self.SharesHeld * Price
-        if Action == 1:
+        if Action == 0:
+            # Hold action: do nothing
+            pass
+        elif Action == 1:
             SharesToBuy = int(self.CurrentBalance // Price)
             self.CurrentBalance -= SharesToBuy * Price
             self.SharesHeld += SharesToBuy
@@ -57,3 +64,7 @@ class TradingEnv(gym.Env):
         Observation = self._GetObservation()
         Info = {"balance": self.CurrentBalance, "shares_held": self.SharesHeld}
         return Observation, Reward, Terminated, False, Info
+
+    # Compatibility method for libraries expecting lower-case names
+    def step(self, Action: int):
+        return self.Step(Action)

--- a/main.py
+++ b/main.py
@@ -1,15 +1,18 @@
 from DataDownloader import YFinanceDownloader
 from TradingEnv import TradingEnv
+from DqnTradingAgent import DqnTradingAgent
 
 
 def Main():
     Downloader = YFinanceDownloader("AAPL", "2020-01-01", "2023-12-31", "1d")
     Data = Downloader.DownloadData()
     Environment = TradingEnv(DataFrame=Data, WindowSize=5, InitialBalance=1000)
+    Agent = DqnTradingAgent(Environment)
+    Agent.Train(Timesteps=1000)
     Observation, Info = Environment.Reset()
     Done = False
     while not Done:
-        Action = Environment.action_space.sample()
+        Action = Agent.Predict(Observation)
         Observation, Reward, Done, _, Info = Environment.Step(Action)
 
 


### PR DESCRIPTION
## Summary
- extend `TradingEnv` to explicitly support a hold action and add compatibility methods
- implement `DqnTradingAgent` using stable-baselines3 DQN
- update `main.py` to train and act using the new agent

## Testing
- `python test_hold_action.py` *(pass)*
- `python test_dqn_agent.py` *(pass)*
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_6843cf412b488320976126dd19bf9cac