### PR TITLE
Add Sharpe-based reward and fees

### DIFF
--- a/TradingEnv.py
+++ b/TradingEnv.py
@@ -4,14 +4,24 @@ import numpy as np
 import pandas as pd
 
 class TradingEnv(gym.Env):
-    def __init__(self, DataFrame: pd.DataFrame, WindowSize: int = 10, InitialBalance: float = 1000.0):
+    def __init__(
+        self,
+        DataFrame: pd.DataFrame,
+        WindowSize: int = 10,
+        InitialBalance: float = 1000.0,
+        TransactionFee: float = 0.0,
+        SharpeRatioWeight: float = 0.0,
+    ):
         super().__init__()
         self.DataFrame = DataFrame.reset_index(drop=True)
         self.WindowSize = WindowSize
         self.InitialBalance = InitialBalance
+        self.TransactionFee = TransactionFee
+        self.SharpeRatioWeight = SharpeRatioWeight
         self.CurrentBalance = self.InitialBalance
         self.SharesHeld = 0
         self.CurrentStep = self.WindowSize
+        self.ReturnsHistory = []
         self.ActionSpace = spaces.Discrete(3)
         self.ObservationSpace = spaces.Box(
             low=-np.inf,
@@ -31,6 +41,7 @@ class TradingEnv(gym.Env):
         self.CurrentBalance = self.InitialBalance
         self.SharesHeld = 0
         self.CurrentStep = self.WindowSize
+        self.ReturnsHistory = []
         Observation = self._GetObservation()
         Info = {"balance": self.CurrentBalance, "shares_held": self.SharesHeld}
         return Observation, Info
@@ -42,15 +53,20 @@ class TradingEnv(gym.Env):
     def Step(self, Action: int):
         Price = float(self.DataFrame.loc[self.CurrentStep, "Close"])
         PortfolioValue = self.CurrentBalance + self.SharesHeld * Price
+        TransactionCost = 0.0
         if Action == 0:
             # Hold action: do nothing
             pass
         elif Action == 1:
             SharesToBuy = int(self.CurrentBalance // Price)
             self.CurrentBalance -= SharesToBuy * Price
+            TransactionCost = SharesToBuy * Price * self.TransactionFee
+            self.CurrentBalance -= TransactionCost
             self.SharesHeld += SharesToBuy
         elif Action == 2:
+            TransactionCost = self.SharesHeld * Price * self.TransactionFee
             self.CurrentBalance += self.SharesHeld * Price
+            self.CurrentBalance -= TransactionCost
             self.SharesHeld = 0
         self.CurrentStep += 1
         if self.CurrentStep >= len(self.DataFrame):
@@ -60,7 +76,17 @@ class TradingEnv(gym.Env):
             Terminated = False
         NextPrice = float(self.DataFrame.loc[self.CurrentStep, "Close"])
         NextValue = self.CurrentBalance + self.SharesHeld * NextPrice
-        Reward = NextValue - PortfolioValue
+        ValueChange = NextValue - PortfolioValue
+        if PortfolioValue != 0:
+            Return = ValueChange / PortfolioValue
+        else:
+            Return = 0.0
+        self.ReturnsHistory.append(Return)
+        if len(self.ReturnsHistory) > 1 and np.std(self.ReturnsHistory) != 0:
+            SharpeRatio = np.sqrt(252) * np.mean(self.ReturnsHistory) / np.std(self.ReturnsHistory)
+        else:
+            SharpeRatio = 0.0
+        Reward = ValueChange - TransactionCost + self.SharpeRatioWeight * SharpeRatio
         Observation = self._GetObservation()
         Info = {"balance": self.CurrentBalance, "shares_held": self.SharesHeld}
         return Observation, Reward, Terminated, False, Info

--- a/main.py
+++ b/main.py
@@ -7,7 +7,13 @@ from PerformanceMetrics import PerformanceMetrics
 def Main():
     Downloader = YFinanceDownloader("AAPL", "2020-01-01", "2023-12-31", "1d")
     Data = Downloader.DownloadData()
-    Environment = TradingEnv(DataFrame=Data, WindowSize=5, InitialBalance=1000)
+    Environment = TradingEnv(
+        DataFrame=Data,
+        WindowSize=5,
+        InitialBalance=1000,
+        TransactionFee=0.001,
+        SharpeRatioWeight=0.1,
+    )
     Agent = DqnTradingAgent(Environment)
     Metrics = PerformanceMetrics(Environment)
     Agent.Train(Timesteps=1000)


### PR DESCRIPTION
## Summary
- account for transaction fees and Sharpe ratio in TradingEnv reward
- pass new parameters from main

## Testing
- `python -m unittest test_trading_env.py`
- `pytest`