### PR TITLE
Add reward penalties for drawdown and volatility

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,8 @@ def Main():
         InitialBalance=1000,
         TransactionFee=0.001,
         SharpeRatioWeight=0.1,
+        DrawdownWeight=0.1,
+        VolatilityWeight=0.05,
     )
     Agent = DqnTradingAgent(
         Environment,


### PR DESCRIPTION
## Summary
- add drawdown and volatility penalties to TradingEnv rewards
- wire new penalty parameters in main

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ee8570548320ba890f6cdca98d83