### PR TITLE
Add indicator factories and new defaults

### DIFF
--- a/FeatureEngineer.py
+++ b/FeatureEngineer.py
@@ -16,7 +16,10 @@ class FeatureEngineer:
             # Register default indicators
             self.RegisterIndicator("SMA_10", self._SimpleMovingAverageFactory(10))
             self.RegisterIndicator("SMA_20", self._SimpleMovingAverageFactory(20))
+            self.RegisterIndicator("EMA_10", self._ExponentialMovingAverageFactory(10))
+            self.RegisterIndicator("MACD", self._MacdFactory())
             self.RegisterIndicator("RSI_14", self._RelativeStrengthIndexFactory(14))
+            self.RegisterIndicator("BBANDS", self._BollingerBandsFactory())
 
     def RegisterIndicator(self, Name: str, Function):
         self.Indicators[Name] = Function
@@ -31,9 +34,33 @@ class FeatureEngineer:
             return ta.rsi(DataFrame["Close"], length=Period)
         return CalculateRSI
 
+    def _ExponentialMovingAverageFactory(self, Period: int):
+        def CalculateEMA(DataFrame: pd.DataFrame):
+            return ta.ema(DataFrame["Close"], length=Period)
+        return CalculateEMA
+
+    def _MacdFactory(self, Fast: int = 12, Slow: int = 26, Signal: int = 9):
+        def CalculateMACD(DataFrame: pd.DataFrame):
+            MacdDf = ta.macd(DataFrame["Close"], fast=Fast, slow=Slow, signal=Signal)
+            MacdDf.columns = ["MACD", "MACDh", "MACDs"]
+            return MacdDf
+        return CalculateMACD
+
+    def _BollingerBandsFactory(self, Length: int = 20, Std: float = 2.0):
+        def CalculateBollinger(DataFrame: pd.DataFrame):
+            BbDf = ta.bbands(DataFrame["Close"], length=Length, std=Std)
+            BbDf.columns = ["BBL", "BBM", "BBU", "BBB", "BBP"]
+            return BbDf
+        return CalculateBollinger
+
     def Transform(self):
         if self.IncludeIndicators:
             for Name, Function in self.Indicators.items():
-                self.DataFrame[Name] = Function(self.DataFrame)
+                Result = Function(self.DataFrame)
+                if isinstance(Result, pd.DataFrame):
+                    for Column in Result.columns:
+                        self.DataFrame[f"{Column}"] = Result[Column]
+                else:
+                    self.DataFrame[Name] = Result
         self.DataFrame.dropna(inplace=True)
         return self.DataFrame

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ def Main():
     Data = Downloader.DownloadData()
     Engineer = FeatureEngineer(Data, IncludeIndicators=True)
     Data = Engineer.Transform()
+    print(Data.head())
     Environment = TradingEnv(
         DataFrame=Data,
         WindowSize=5,


### PR DESCRIPTION
## Summary
- extend default indicators to include EMA, MACD, RSI and Bollinger Bands
- add factories for EMA, MACD and Bollinger Bands
- enhance Transform to append DataFrame outputs
- print first rows of data in main after applying indicators