### PR TITLE
Fix reward calculation in TradingEnv

### DIFF
--- a/TradingEnv.py
+++ b/TradingEnv.py
@@ -115,7 +115,6 @@ class TradingEnv(gym.Env):
             Drawdown = 0.0
         Reward = (
             ValueChange
-            - TransactionCost
             + self.SharpeRatioWeight * SharpeRatio
             - self.DrawdownWeight * Drawdown
             - self.VolatilityWeight * Volatility


### PR DESCRIPTION
## Summary
- fix reward formula to avoid double-counting transaction fees
- keep `main.py` usage the same

## Testing
- `python TestTradingEnvReward.py` *(removed afterward)*
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_6844122527808320aac87a4cc1bb3db8